### PR TITLE
Specific BrowserWindow in ngBridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,15 @@ Send a message to the AngularJS client:
 
 ```javascript
 // Electron : index,js
+
+// Specify a BrowserWindow
+angular.send("Hello from the host.", mainWindow);
+
+// If no BrowserWindow is specified, ng-bridge will attempt to capture the window that is focused in the application.
 angular.send("Hello from the host.");
 ```
+**Note** If a window is neither specified, or found, the message will not send to the client.
+
 ---
 
 ## Calling Electron from AngularJS

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,14 @@
 {
   "name": "ng-electron",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "main": "ng-electron.js",
   "authors": [
     "Chris Byerley <cbyerley@develephant.com>"
   ],
+  "contributors": [{
+    "name": "Mark Rabey",
+    "email": "mark@markrabey.com"
+  }],
   "description": "Enables AngularJS and Electron to integrate together easier.",
   "keywords": [
     "AngularJS",

--- a/ng-bridge.js
+++ b/ng-bridge.js
@@ -6,12 +6,14 @@
 **/
 var angularBridge = new Object();
 
-angularBridge.send = function ( msg ) {
+angularBridge.send = function ( msg, bw ) {
   var msg = msg;
-  var bw = require('browser-window')
-  .getFocusedWindow()
-  .webContents
-  .send('ELECTRON_BRIDGE_CLIENT', msg);
+  bw = bw || require('browser-window').getFocusedWindow();
+
+  if (bw) {
+    bw.webContents
+      .send('ELECTRON_BRIDGE_CLIENT', msg);
+  }
 }
 angularBridge.listen = function ( _listener ) {
   var _listener = _listener;

--- a/ng-electron.js
+++ b/ng-electron.js
@@ -3,7 +3,7 @@
  * (c)2015 C. Byerley @develephant
  * http://develephant.github.io/ngElectron
  * See also: https://develephant.gitgub.io/amy
- * Version 0.3.3
+ * Version 0.4.0
  */
 'use strict';
 


### PR DESCRIPTION
Handles Issue #1 - allows to pass in a specific window to be targeted when sending a message. If no message is found, it will send to the focused window. If a window is neither specified or in focus, the message will not send.

I have updated to code to reflect the version number 0.4.0, as I feel this is an added feature, not a bug fix.
